### PR TITLE
Remove trailing ! in test description

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,6 +1,6 @@
 describe('index', function() {
   describe('iterativeLog(array)', function() {
-    it('logs each element with the format `${index}: ${element}!`', function() {
+    it('logs each element with the format `${index}: ${element}`', function() {
       const log = expect.spyOn(console, 'log').andCallThrough()
 
       iterativeLog([1, 2, 3])


### PR DESCRIPTION
Remove the `!` from the test description so that it's an accurate representation of what the tests expect

Example:

``` javascript
expect(log).toHaveBeenCalledWith('0: 1')
expect(log).toHaveBeenCalledWith('1: 2')
expect(log).toHaveBeenCalledWith('2: 3')
```
